### PR TITLE
문서 빌드 안되는 버그 수정

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 16
+      - run: apt install dos2unix
       - name: 문서 빌드
         run: |
           dos2unix gradlew


### PR DESCRIPTION
dos2unix 따로안깔았을때 제가할때는 잘됐는데 왜 안될까요 그래서 수정했어요