### PR TITLE
Let's write with Scala! ( Add ScalaSupport and Sample for them ! ) + ⭐ Bundle Abilities ! (+necromancer, location-magic) ⭐

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build/
 
 # BuildTools
 .buildtools/
+/runserver.lnk
+/#suggests/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ subprojects {
         implementation(kotlin("reflect"))
 
         implementation("io.github.monun:tap-api:4.1.9")
-        implementation("com.google.guava:guava:30.1.1-jre")
         implementation("org.scala-lang:scala-library:2.13.6")
 
         testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ allprojects {
 
 subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "scala")
 
     repositories {
         maven("https://papermc.io/repo/repository/maven-public/")
@@ -36,9 +37,16 @@ subprojects {
         implementation(kotlin("reflect"))
 
         implementation("io.github.monun:tap-api:4.1.9")
+        implementation("com.google.guava:guava:30.1.1-jre")
+        implementation("org.scala-lang:scala-library:2.13.6")
 
         testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.2")
         testImplementation("org.mockito:mockito-core:3.6.28")
+        testImplementation("org.scalatest:scalatest_2.13:3.2.9")
+        testImplementation("org.scalatestplus:junit-4-13_2.13:3.2.2.0")
+        testImplementation("junit:junit:4.13.2")
+
+        testRuntimeOnly("org.scala-lang.modules:scala-xml_2.13:1.2.0")
     }
 }

--- a/psychics-abilities/ability-location-magic/src/main/resources/ability.yml
+++ b/psychics-abilities/ability-location-magic/src/main/resources/ability.yml
@@ -1,0 +1,5 @@
+group: com.github.muqhc
+name: ${projectName}
+version: ${version}
+main: com.github.muqhc.psychics.ability.${packageName}.Ability${abilityName.capitalize()}
+author: muqhc

--- a/psychics-abilities/ability-location-magic/src/main/scala/com/github/muqhc/psychics/ability/locationmagic/AbilityLocationMagic.scala
+++ b/psychics-abilities/ability-location-magic/src/main/scala/com/github/muqhc/psychics/ability/locationmagic/AbilityLocationMagic.scala
@@ -1,0 +1,124 @@
+package com.github.muqhc.psychics.ability.locationmagic
+
+import io.github.monun.psychics.ActiveAbility.WandAction
+import io.github.monun.psychics.scalasupport.ScalaFireworkSupportKt.playFirework
+import io.github.monun.psychics._
+import io.github.monun.tap.config.{Config, Name}
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.entity.{Entity, LivingEntity}
+import org.bukkit.event.player.PlayerEvent
+import org.bukkit.inventory.ItemStack
+import org.bukkit._
+
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+
+
+@Name("location-magic")
+class AbilityConceptLocationMagic extends AbilityConcept {
+
+    @Config
+    var costPerTargetCount = 10
+
+    @Config
+    var cooldownTimePerTargetCount = 1000
+
+    //region Set Common Init
+
+    this setType AbilityType.ACTIVE
+    this setDisplayName "Location Magic"
+
+    this setCost 20
+    this setCooldownTime 1000
+
+    this setCastingTime 1000
+
+    this setRange 64
+
+    this setWand new ItemStack(Material.STICK,1)
+
+    this setSupplyItems List(getWand).asJava
+
+    val predescription = List(
+        "시전시간 동안 지정된 엔티티들의 위치들을",
+        "지정순으로 각 뒷순서의 위치로 바꾸어 버립니다.",
+        "",
+        "소모 마나와 쿨타임은 타겟팅 수에 비례합니다."
+    )
+    this setDescription predescription.map(text).asJava
+
+
+    //endregion
+
+}
+
+class AbilityLocationMagic extends ActiveAbility[AbilityConceptLocationMagic] {
+
+    def esper: Esper = getEsper
+    def concept: AbilityConceptLocationMagic = getConcept
+
+    val effect: FireworkEffect = FireworkEffect.builder().withColor(Color.PURPLE).`with`(FireworkEffect.Type.BALL_LARGE).build()
+
+    def playPsychicEffect(target: LivingEntity): Unit = {
+        playFirework(target.getWorld,target.getLocation(),effect,128.0)
+    }
+
+
+    val targets : ListBuffer[LivingEntity] = ListBuffer.empty
+    def getTargetsLocations: ListBuffer[Location] = targets map { e: LivingEntity => e.getLocation }
+
+    def getTarget: Entity = {
+        val player = esper.getPlayer
+        val start = player.getEyeLocation
+        val world = start.getWorld
+
+        world.rayTrace(
+            start,
+            start.getDirection,
+            concept.getRange,
+            FluidCollisionMode.NEVER,
+            true,
+            0.5,
+            (t: Entity) => t != player
+        ).getHitEntity
+    }
+
+
+    override def onInitialize(): Unit = {
+
+    }
+
+
+    override def onChannel(channel: Channel): Unit = {
+        getTarget match {
+            case target: LivingEntity => if (!(targets contains target)) targets += target
+            case _ =>
+        }
+        targets foreach (e=>if(e != null)e.getWorld.spawnParticle(Particle.PORTAL,e.getLocation,10,0,0,0,0.03))
+    }
+
+    override def onCast(event: PlayerEvent, action: WandAction, target: Any): Unit = {
+        if (targets.isEmpty) return ;
+        if ((concept.costPerTargetCount * targets.length + concept.getCost) > psychic.getMana)
+            esper.getPlayer.sendActionBar(text("too much targets! (not Enough Mana.)") color NamedTextColor.DARK_PURPLE)
+
+        val targetsLocations = getTargetsLocations
+        targetsLocations += targetsLocations.head
+        targetsLocations remove 0
+
+        val targetsWithLocations = targets zip targetsLocations
+        targetsWithLocations foreach {
+            case (entity, location: Location) =>
+                entity teleport location
+                playPsychicEffect(entity)
+        }
+
+        psychic consumeMana (concept.costPerTargetCount * targets.length + concept.getCost)
+        this setCooldownTime (concept.cooldownTimePerTargetCount * targets.length + concept.getCooldownTime)
+
+        targets.clear()
+
+    }
+
+}

--- a/psychics-abilities/ability-necromancer/src/main/resources/ability.yml
+++ b/psychics-abilities/ability-necromancer/src/main/resources/ability.yml
@@ -1,0 +1,5 @@
+group: com.github.muqhc
+name: ${projectName}
+version: ${version}
+main: com.github.muqhc.psychics.ability.${packageName}.Ability${abilityName.capitalize()}
+author: muqhc

--- a/psychics-abilities/ability-necromancer/src/main/scala/com/github/muqhc/psychics/ability/necromancer/AbilityNecromancer.scala
+++ b/psychics-abilities/ability-necromancer/src/main/scala/com/github/muqhc/psychics/ability/necromancer/AbilityNecromancer.scala
@@ -1,0 +1,346 @@
+package com.github.muqhc.psychics.ability.necromancer
+
+import io.github.monun.psychics.PsychicProjectile
+import io.github.monun.psychics.ActiveAbility.WandAction
+import io.github.monun.psychics.attribute.EsperStatistic
+import io.github.monun.psychics.damage.{Damage, DamageType}
+import io.github.monun.psychics.scalasupport.ScalaDamageSupportKt.{scala_psychicDamage_aDamage, scala_psychicDamage_simple}
+import io.github.monun.psychics.tooltip.TooltipBuilder
+import io.github.monun.psychics.util.TargetFilter
+import io.github.monun.psychics.{AbilityConcept, ActiveAbility, Channel, _}
+import io.github.monun.tap.config.{Config, Name}
+import io.github.monun.tap.fake.Trail
+import kotlin.jvm.functions
+import net.kyori.adventure.text.Component.text
+import net.kyori.adventure.text.format.{NamedTextColor, TextDecoration}
+import org.bukkit.attribute.Attribute
+import org.bukkit.block.Block
+import org.bukkit.{Color, Material, util, _}
+import org.bukkit.entity.{Entity, EntityType, LivingEntity, Mob, Monster}
+import org.bukkit.event.{EventHandler, Listener}
+import org.bukkit.event.player.{PlayerEvent, PlayerInteractEvent}
+import org.bukkit.inventory.ItemStack
+import org.bukkit.potion.{PotionEffect, PotionEffectType}
+
+import java.lang
+import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
+import scala.math.{Pi, cos, sin}
+
+
+@Name("necromancer")
+class AbilityConceptNecromancer extends AbilityConcept {
+
+    @Config
+    var periodicDamage = new Damage(DamageType.RANGED,EsperStatistic.deserialize(
+        Map("ATK" -> 0.8).asJava
+    ))
+
+    @Config
+    var attackPeriodTicks = 13
+
+    @Config
+    var orbSpeed = 1.8
+
+    @Config
+    var orbGravity = 0.1
+
+    @Config
+    var orbSize = 1.0
+
+    @Config
+    var slowAmplifier = 3
+
+    @Config
+    var slowDurationTicks = 60
+
+    @Config
+    var deadAreaHoldingTicks = 200
+
+    @Config
+    var deadAreaMinMaxRange = List(1.2,6.0).asJava
+
+    @Config
+    var deadAreaIncreasePerTick = 0.13
+
+    /**<h1><hr><font color="yellow">Deep Config</font></h1>*/
+    var spawnEntityAtEachRange = Map(
+        2.6 -> EntityType.ZOMBIE,
+        5.7 -> EntityType.SKELETON,
+        9.5 -> EntityType.BLAZE,
+    )
+
+    //region Set Common Init
+
+    this setType AbilityType.ACTIVE
+    this setDisplayName "Necromancer"
+
+    this setCost 50
+    this setCooldownTime 100
+
+    this setCastingTime 500
+
+    this setRange 64
+
+    this setDamage new Damage(DamageType.RANGED,EsperStatistic.deserialize(
+    Map("ATK" -> 4.0).asJava
+    ))
+
+    this setWand new ItemStack(Material.DIAMOND,1)
+
+    this setSupplyItems List(getWand).asJava
+
+    val predescription = List(
+        "투사체가 떨어진 자리에 죽음의 지역을 만듭니다.",
+        "   죽음의 지역은 지역안에 엔티티에게",
+        "   지속적인 피해와 구속 효과를 줍니다.",
+        "   죽음의 지역은 일정크기 까지 서서히 커집니다.",
+        "",
+        "투사체가 떨어진 자리에서 가장 가까운 몹과의 거리에 따라",
+        "   소환되는 몬스터가 달라집니다. (너무 멀면 소환 안 됨.)",
+        "",
+        "해당 몬스터는 가장 가까운 엔티티를 타겟팅 합니다."
+    )
+    this setDescription predescription.map(text).asJava
+
+
+    //endregion
+
+    override def onRenderTooltip(tooltip: TooltipBuilder, stats: functions.Function1[_ >: EsperStatistic, lang.Double]): Unit = {
+        tooltip.header(
+            text().color(NamedTextColor.DARK_PURPLE).content("죽음의 지역 지속 피해 ").decorate(TextDecoration.BOLD)
+                .append(
+                    text().color(NamedTextColor.DARK_RED).append(text(periodicDamage.toString))
+                ).build()
+        )
+    }
+}
+
+class AbilityNecromancer extends ActiveAbility[AbilityConceptNecromancer] with Listener {
+
+    def thisFilter(filteringEntity: LivingEntity = null): LivingEntity => Boolean = (entity: LivingEntity) => new TargetFilter(esper.getPlayer,
+        Bukkit.getScoreboardManager.getMainScoreboard.getEntryTeam(esper.getPlayer.name.toString)).test(entity) && entity != filteringEntity
+
+    def spawnEntityAtEachRange: Map[Double, EntityType] = concept.spawnEntityAtEachRange
+
+    def RangeGetters: Map[Double => Boolean, EntityType] =
+        spawnEntityAtEachRange map {
+            case (r,m) => ((x: Double) => x <= r) -> m
+        }
+
+    def esper: Esper = getEsper
+    def concept: AbilityConceptNecromancer = getConcept
+
+    val deadAreas: ListBuffer[DeadArea] = ListBuffer[DeadArea]()
+
+    override def onInitialize(): Unit = {
+
+    }
+
+    override def onEnable() {
+        psychic.runTaskTimer(new Task(), 0, 1)
+    }
+
+    override def onCast(event: PlayerEvent, action: WandAction, target: Any): Unit = {
+
+        psychic consumeMana concept.getCost
+        this setCooldownTime concept.getCooldownTime
+
+        val location = esper.getPlayer.getEyeLocation
+        val projectile = new DeadOrbProjectile()
+
+        psychic.launchProjectile(location, projectile)
+        projectile setVelocity location.getDirection.multiply(concept.orbSpeed)
+
+        location.getWorld.playSound(location, Sound.ENTITY_BLAZE_SHOOT, 1.0F, 0.1F)
+
+    }
+
+    class DeadArea(location: Location, holdingTicks: Int, minrange : Double, maxrange : Double, increasePerTick : Double, summoningMonster : EntityType) {
+        var tick: Int = holdingTicks
+        var range: Double = minrange
+
+        lazy val processes: ListBuffer[() => Any] = ListBuffer[() => Any](
+            rangeEffect,
+            ()=>{
+                if (range < maxrange) range += increasePerTick
+                else promises += (() => processes remove 1)
+            },
+                ()=>{ if (tick % concept.attackPeriodTicks == 0) promises += (()=>attack(concept.periodicDamage, 0.01)) }
+        )
+
+        val promises: ListBuffer[() => Any] = ListBuffer[() => Any]()
+
+        promises += (()=>attack(concept.getDamage, concept.getKnockback))
+
+        def rangeEffect(): Unit = {
+            var effectloc: Location = location.clone()
+            var x = tick*Pi*0.53
+            effectloc setX (effectloc.getX + sin(x) * range)
+            effectloc setY  (effectloc.getY + 2)
+            effectloc setZ (effectloc.getZ + cos(x) * range)
+            location.getWorld.spawnParticle(
+                    Particle.DRAGON_BREATH,effectloc,4,0.0,0.1,0.0,0.03)
+            effectloc = location.clone()
+            x = -x
+            effectloc setX (effectloc.getX + sin(x) * range)
+            effectloc setY  (effectloc.getY + 2)
+            effectloc setZ (effectloc.getZ + cos(x) * range)
+            location.getWorld.spawnParticle(
+                Particle.DRAGON_BREATH,effectloc,4,0.0,0.1,0.0,0.03)
+        }
+
+        def getUndead: Mob = {
+            summoningMonster match {
+                case entityType: EntityType if (entityType != null) =>
+                    val entity = location.getWorld.spawnEntity(location, summoningMonster).asInstanceOf[Mob]
+                    processes += (() => {
+                        val nearestKV = nearest(entity.getLocation,20,thisFilter(entity))
+                        if (nearestKV == null) return null
+                        entity setTarget nearestKV._2
+                    })
+                    entity
+                case _ => null
+            }
+        }
+
+        val undead: LivingEntity = getUndead
+        if (undead != null) undead.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED).setBaseValue(0.37)
+
+
+        def update(): Unit = {
+            tick = tick - 1
+            if (tick < 0) {
+                deadAreas -= this
+                undead.remove()
+            }
+            processes foreach (_ ())
+            promises foreach (_ ())
+            promises.clear()
+        }
+
+        def attack(damage: Damage, knockback : Double): Unit = {
+            nearbyentity(location,range,thisFilter(undead)) foreach (target=>{
+                scala_psychicDamage_aDamage(AbilityNecromancer.this, target, damage, location, knockback)
+                val potionEffect = new PotionEffect(
+                        PotionEffectType.SLOW,
+                        concept.slowDurationTicks,
+                        concept.slowAmplifier,
+                false,
+                false,
+                false
+                )
+                target.addPotionEffect(potionEffect)
+            })
+        }
+
+    }
+
+    class DeadOrbProjectile() extends PsychicProjectile(1200, concept.getRange) {
+        override def onPreUpdate(): Unit = {
+            this setVelocity new util.Vector(getVelocity.getX, getVelocity.getY - concept.orbGravity, getVelocity.getZ)
+        }
+
+        override def onTrail(trail: Trail): Unit = {
+            val velocity = trail.getVelocity
+            val length = velocity.normalize().length()
+
+            if (length > 0.0) {
+                val start = trail.getFrom
+                val world = start.getWorld
+
+                world.spawnParticle(
+                        Particle.DRAGON_BREATH,
+                        trail.getTo,
+                32,
+                0.0,
+                0.0,
+                0.0,
+                0.013,
+                null,
+                true
+                )
+
+                val result = world.rayTrace(
+                        start, velocity, length, FluidCollisionMode.NEVER, true, concept.orbSize / 2.0,
+                new TargetFilter(esper.getPlayer,Bukkit.getScoreboardManager.getMainScoreboard.getEntryTeam(esper.getPlayer.name.toString))
+                )
+
+                if (result == null) return ;
+
+                val hitLocation = result.getHitPosition.toLocation(world)
+
+                remove()
+
+                world.spawnParticle(
+                        Particle.DRAGON_BREATH,
+                        hitLocation,
+                32,
+                0.2,
+                1.0,
+                0.2,
+                4.0,
+                null,
+                true
+                )
+
+                val nearestKV = nearest(hitLocation,spawnEntityAtEachRange.keys.max)
+                def willSpawnEntity(): EntityType = {
+                    if (nearestKV == null) return null
+                    for (getter <- RangeGetters) {
+                        if (getter._1(nearestKV._1)) return getter._2
+                    }
+                    null
+                }
+                val areaLoc = hitLocation.clone()
+                areaLoc setY hitLocation.getY + 2
+                deadAreas += new DeadArea(hitLocation, concept.deadAreaHoldingTicks,
+                        concept.deadAreaMinMaxRange.get(0), concept.deadAreaMinMaxRange.get(1), concept.deadAreaIncreasePerTick,
+                        willSpawnEntity())
+
+
+                world.playSound(hitLocation, Sound.ENTITY_ENDERMAN_SCREAM, 2.0F, 0.1F)
+
+            }
+        }
+    }
+
+    class Task extends Runnable {
+        override def run(): Unit = {
+            deadAreas foreach (area => area.update())
+        }
+    }
+
+    def nearbyentity(location: Location, range: Double, filter: LivingEntity => Boolean = thisFilter()): List[LivingEntity] = {
+        val nearbyRaw = location.getWorld.getEntities
+        var nearby = List[Entity]()
+        var i = 0
+        while (nearbyRaw.size() > i) {
+            nearby = nearbyRaw.get(i) :: nearby
+            i += 1
+        }
+        nearby collect {
+            case e: LivingEntity => e
+        } filter (e => location.distance(e.getLocation()) <= range) filter filter
+    }
+    def nearbyentityMap(location: Location, range: Double, filter: LivingEntity => Boolean = thisFilter()): Map[Double,LivingEntity] = {
+        val nearbyRaw = location.getWorld.getEntities
+        var nearby = List[Entity]()
+        var i = 0
+        while (nearbyRaw.size() > i) {
+            nearby = nearbyRaw.get(i) :: nearby
+            i += 1
+        }
+        (nearby collect {
+            case e: LivingEntity => e
+        } filter (e => location.distance(e.getLocation()) <= range) filter filter map
+            (e => location.distance(e.getLocation()) -> e)).toMap
+    }
+
+    def nearest(location: Location, range: Double, filter: LivingEntity => Boolean = thisFilter()): (Double, LivingEntity) = {
+        val nearby = nearbyentityMap(location, range, filter)
+        if (nearby.keys.isEmpty) return null
+        nearby.keys.min -> nearby(nearby.keys.min)
+    }
+
+}

--- a/psychics-abilities/ability-sample-scala/src/main/resources/ability.yml
+++ b/psychics-abilities/ability-sample-scala/src/main/resources/ability.yml
@@ -1,0 +1,5 @@
+group: com.github.muqhc
+name: ${projectName}
+version: ${version}
+main: com.github.muqhc.psychics.ability.${packageName}.Ability${abilityName.capitalize()}
+author: muqhc

--- a/psychics-abilities/ability-sample-scala/src/main/scala/com/github/muqhc/psychics/ability/samplescala/AbilitySampleScala.scala
+++ b/psychics-abilities/ability-sample-scala/src/main/scala/com/github/muqhc/psychics/ability/samplescala/AbilitySampleScala.scala
@@ -92,17 +92,15 @@ class AbilitySampleScala extends ActiveAbility[AbilityConceptSampleScala] with L
         })
     }
 
-    override def onCast(event: PlayerEvent, action: WandAction, target: Any): Unit = {
+    override def onCast(event: PlayerEvent, action: WandAction, target: Any): Unit = target match {
+        case target: LivingEntity =>
+            val concept = getConcept
 
-        if (!target.isInstanceOf[LivingEntity]) return ;
+            psychic consumeMana concept.getCost
+            this setCooldownTime concept.getCooldownTime
 
-        val concept = getConcept
-
-        psychic consumeMana concept.getCost
-        this setCooldownTime concept.getCooldownTime
-
-        scala_psychicDamage_simple(this, target.asInstanceOf[LivingEntity])
-        playPsychicEffect(target.asInstanceOf[LivingEntity])
+            scala_psychicDamage_simple(this, target)
+            playPsychicEffect(target)
 
     }
 

--- a/psychics-abilities/ability-sample-scala/src/main/scala/com/github/muqhc/psychics/ability/samplescala/AbilitySampleScala.scala
+++ b/psychics-abilities/ability-sample-scala/src/main/scala/com/github/muqhc/psychics/ability/samplescala/AbilitySampleScala.scala
@@ -1,0 +1,109 @@
+package com.github.muqhc.psychics.ability.samplescala
+
+import io.github.monun.psychics.ActiveAbility.WandAction
+import io.github.monun.psychics.attribute.EsperStatistic
+import io.github.monun.psychics.damage.{Damage, DamageType}
+import io.github.monun.psychics.scalasupport.ScalaDamageSupportKt.scala_psychicDamage_simple
+import io.github.monun.psychics.scalasupport.ScalaFireworkSupportKt.playFirework
+import io.github.monun.psychics.util.TargetFilterKt.hostileFilter
+import io.github.monun.psychics.{AbilityConcept, ActiveAbility, Channel, _}
+import io.github.monun.tap.config.{Config, Name}
+import net.kyori.adventure.text.Component.text
+import org.bukkit.{Color, FireworkEffect, Material, _}
+import org.bukkit.entity.{Entity, LivingEntity}
+import org.bukkit.event.block.Action
+import org.bukkit.event.{EventHandler, Listener}
+import org.bukkit.event.player.{PlayerEvent, PlayerInteractEvent}
+import org.bukkit.inventory.ItemStack
+
+import java.util
+import scala.jdk.CollectionConverters._
+
+
+@Name("sample-scala")
+class AbilityConceptSampleScala extends AbilityConcept {
+
+    @Config
+    var sampleConfigNumber = 0.0
+
+    @Config
+    var sampleConfigList: util.List[Int] = List(0,1,2).asJava
+
+    @Config
+    var sampleConfigMapList: util.List[util.Map[String, Int]] = List(Map("a"->1).asJava,Map("b"->2).asJava).asJava
+
+    //region Set Common Init
+
+    this setType AbilityType.ACTIVE
+    this setDisplayName "Sample for Scala Ability"
+
+    this setCost 10
+    this setCooldownTime 5000
+
+    this setCastingTime 1000
+
+    this setRange 64
+
+    this setDamage new Damage(DamageType.RANGED,EsperStatistic.deserialize(
+    Map("ATK" -> 4.0).asJava
+    ))
+
+    this setWand new ItemStack(Material.STICK,1)
+
+    this setSupplyItems List(getWand).asJava
+
+    val predescription = List(
+    "지정한 대상에게 폭발을 일으킵니다."
+    )
+    this setDescription predescription.map(text).asJava
+
+
+    //endregion
+
+}
+
+class AbilitySampleScala extends ActiveAbility[AbilityConceptSampleScala] with Listener {
+
+    def esper: Esper = getEsper
+    def concept: AbilityConceptSampleScala = getConcept
+
+    val effect: FireworkEffect = FireworkEffect.builder().withColor(Color.RED).`with`(FireworkEffect.Type.BURST).build()
+
+
+    def playPsychicEffect(target: LivingEntity): Unit = {
+        playFirework(target.getWorld,target.getLocation(),effect,128.0)
+    }
+
+    override def onInitialize(): Unit = {
+        this setTargeter (() => {
+            val player = esper.getPlayer
+            val start = player.getEyeLocation
+            val world = start.getWorld
+
+            world.rayTrace(
+                start,
+                start.getDirection,
+                concept.getRange,
+                FluidCollisionMode.NEVER,
+                true,
+                0.5,
+                hostileFilter(player)
+            ).getHitEntity
+        })
+    }
+
+    override def onCast(event: PlayerEvent, action: WandAction, target: Any): Unit = {
+
+        if (!target.isInstanceOf[LivingEntity]) return ;
+
+        val concept = getConcept
+
+        psychic consumeMana concept.getCost
+        this setCooldownTime concept.getCooldownTime
+
+        scala_psychicDamage_simple(this, target.asInstanceOf[LivingEntity])
+        playPsychicEffect(target.asInstanceOf[LivingEntity])
+
+    }
+
+}

--- a/psychics-abilities/ability-sample-scala/src/main/scala/com/github/muqhc/psychics/ability/samplescala/AbilitySampleScala.scala
+++ b/psychics-abilities/ability-sample-scala/src/main/scala/com/github/muqhc/psychics/ability/samplescala/AbilitySampleScala.scala
@@ -62,7 +62,7 @@ class AbilityConceptSampleScala extends AbilityConcept {
 
 }
 
-class AbilitySampleScala extends ActiveAbility[AbilityConceptSampleScala] with Listener {
+class AbilitySampleScala extends ActiveAbility[AbilityConceptSampleScala] {
 
     def esper: Esper = getEsper
     def concept: AbilityConceptSampleScala = getConcept

--- a/psychics-core/build.gradle.kts
+++ b/psychics-core/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     implementation("io.github.monun:kommand-api:2.6.6")
     implementation("io.github.monun:invfx-api:3.0.1")
+    implementation(kotlin("script-runtime"))
 }
 
 tasks {

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/PsychicManager.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/PsychicManager.kt
@@ -138,6 +138,7 @@ class PsychicManager(
 
         for ((file, description) in descriptions) {
             abilityLoader.runCatching {
+                logger.info("Loading Ability ${description.artifactId} : ${description.main}")
                 map[description.artifactId] = load(file, description)
             }.onFailure { exception: Throwable ->
                 exception.printStackTrace()

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/damage/Damage.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/damage/Damage.kt
@@ -23,7 +23,7 @@ import net.md_5.bungee.api.ChatColor
 import org.bukkit.configuration.ConfigurationSection
 import org.bukkit.configuration.serialization.ConfigurationSerializable
 
-class Damage internal constructor(
+class Damage(
     val type: DamageType,
     val stats: EsperStatistic
 ) : ConfigurationSerializable {

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityClassLoader.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityClassLoader.kt
@@ -17,8 +17,6 @@
 
 package io.github.monun.psychics.loader
 
-import org.bukkit.Bukkit
-import org.bukkit.ChatColor
 import java.io.File
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
@@ -34,12 +32,9 @@ internal class AbilityClassLoader(
 
     @Throws(ClassNotFoundException::class)
     override fun findClass(name: String): Class<*> {
-        val log = Bukkit.getLogger()
-        log.info(" -Abilities- Loading Class - $name")
         return try {
             findLocalClass(name)
         } catch (e: ClassNotFoundException) {
-            log.info("${ChatColor.AQUA}  >>Trying loading $name at Global")
             loader.findClass(name, this)
         }
     }

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityClassLoader.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityClassLoader.kt
@@ -17,6 +17,8 @@
 
 package io.github.monun.psychics.loader
 
+import org.bukkit.Bukkit
+import org.bukkit.ChatColor
 import java.io.File
 import java.net.URLClassLoader
 import java.util.concurrent.ConcurrentHashMap
@@ -32,9 +34,12 @@ internal class AbilityClassLoader(
 
     @Throws(ClassNotFoundException::class)
     override fun findClass(name: String): Class<*> {
+        val log = Bukkit.getLogger()
+        log.info(" -Abilities- Loading Class - $name")
         return try {
             findLocalClass(name)
         } catch (e: ClassNotFoundException) {
+            log.info("${ChatColor.AQUA}  >>Trying loading $name at Global")
             loader.findClass(name, this)
         }
     }

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityLoader.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityLoader.kt
@@ -21,6 +21,8 @@ import io.github.monun.psychics.Ability
 import io.github.monun.psychics.AbilityConcept
 import io.github.monun.psychics.AbilityContainer
 import io.github.monun.psychics.AbilityDescription
+import org.bukkit.Bukkit
+import org.bukkit.ChatColor
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
@@ -36,12 +38,15 @@ class AbilityLoader internal constructor() {
 
         val classLoader = AbilityClassLoader(this, file, javaClass.classLoader)
 
+        val log = Bukkit.getLogger()
         try {
+            log.info(" <Ability> Loading Ability :> ${description.main}")
             val abilityClass =
                 Class.forName(description.main, true, classLoader).asSubclass(Ability::class.java) //메인 클래스 찾기
             val abilityKClass = abilityClass.kotlin
             val conceptClassName =
-                abilityKClass.supertypes.first().arguments.first().type.toString().removePrefix("class ")
+                abilityKClass.supertypes.first().arguments.first().type.toString().removePrefix("class ").removeSuffix("!")
+            log.info(" <AbilityConcept> Loading AbilityConcept :> $conceptClassName")
             val conceptClass = Class.forName(conceptClassName, true, classLoader).asSubclass(AbilityConcept::class.java)
 
             testCreateInstance(abilityClass)
@@ -87,9 +92,11 @@ class AbilityLoader internal constructor() {
 }
 
 private fun <T> testCreateInstance(clazz: Class<T>): T {
+    val log = Bukkit.getLogger()
+    log.info(clazz.toString())
     try {
         return clazz.getConstructor().newInstance()
     } catch (e: Exception) {
-        error("Failed to create instance ${clazz.name}")
+        throw e
     }
 }

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityLoader.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/loader/AbilityLoader.kt
@@ -38,15 +38,12 @@ class AbilityLoader internal constructor() {
 
         val classLoader = AbilityClassLoader(this, file, javaClass.classLoader)
 
-        val log = Bukkit.getLogger()
         try {
-            log.info(" <Ability> Loading Ability :> ${description.main}")
             val abilityClass =
                 Class.forName(description.main, true, classLoader).asSubclass(Ability::class.java) //메인 클래스 찾기
             val abilityKClass = abilityClass.kotlin
             val conceptClassName =
                 abilityKClass.supertypes.first().arguments.first().type.toString().removePrefix("class ").removeSuffix("!")
-            log.info(" <AbilityConcept> Loading AbilityConcept :> $conceptClassName")
             val conceptClass = Class.forName(conceptClassName, true, classLoader).asSubclass(AbilityConcept::class.java)
 
             testCreateInstance(abilityClass)
@@ -92,8 +89,6 @@ class AbilityLoader internal constructor() {
 }
 
 private fun <T> testCreateInstance(clazz: Class<T>): T {
-    val log = Bukkit.getLogger()
-    log.info(clazz.toString())
     try {
         return clazz.getConstructor().newInstance()
     } catch (e: Exception) {

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/scalasupport/ScalaDamageSupport.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/scalasupport/ScalaDamageSupport.kt
@@ -1,0 +1,55 @@
+package io.github.monun.psychics.scalasupport
+
+import io.github.monun.psychics.Ability
+import io.github.monun.psychics.AbilityConcept
+import io.github.monun.psychics.damage.Damage
+import io.github.monun.psychics.damage.DamageType
+import io.github.monun.psychics.damage.psychicDamage
+import io.github.monun.psychics.damage.psychicHeal
+import org.bukkit.Location
+import org.bukkit.entity.LivingEntity
+import org.bukkit.entity.Player
+
+fun scala_psychicDamage(
+    ability: Ability<out AbilityConcept>,
+    target: LivingEntity,
+    damageType: DamageType,
+    damage: Double,
+    damager: Player,
+    knockbackSource: Location? = damager.location,
+    knockbackForce: Double = 0.0
+) = target.psychicDamage(ability, damageType, damage, damager, knockbackSource, knockbackForce)
+
+fun scala_psychicDamage_aDamage(
+    ability: Ability<out AbilityConcept>,
+    target: LivingEntity,
+    damage: Damage? = ability.concept.damage,
+    knockbackLocation: Location? = ability.esper.player.location,
+    knockback: Double = ability.concept.knockback
+) = target.psychicDamage(
+    ability,
+    damage!!.type,
+    damage = ability.esper.getStatistic(damage.stats),
+    damager = ability.esper.player,
+    knockbackSource = knockbackLocation,
+    knockbackForce = knockback
+)
+
+fun scala_psychicDamage_simple(
+    ability: Ability<out AbilityConcept>,
+    target: LivingEntity
+) = target.psychicDamage(
+    ability,
+    ability.concept.damage!!.type,
+    damage = ability.esper.getStatistic(ability.concept.damage!!.stats),
+    damager = ability.esper.player,
+    knockbackSource = ability.esper.player.location,
+    knockbackForce = ability.concept.knockback
+)
+
+fun scala_psychicHeal(
+    ability: Ability<out AbilityConcept>,
+    target: LivingEntity,
+    amount: Double,
+    healer: Player
+) = target.psychicHeal(ability, amount, healer)

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/scalasupport/ScalaFireworkSupport.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/scalasupport/ScalaFireworkSupport.kt
@@ -1,0 +1,13 @@
+package io.github.monun.psychics.scalasupport
+
+import io.github.monun.tap.effect.playFirework
+import org.bukkit.FireworkEffect
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.entity.Player
+import org.bukkit.util.Vector
+
+fun playFirework(player: Player, x: Double, y: Double, z: Double, effect: FireworkEffect) = player.playFirework(x, y, z, effect)
+fun playFirework(world: World, x: Double, y: Double, z: Double, effect: FireworkEffect, distance: Double = 128.0) = world.playFirework(x, y, z, effect, distance)
+fun playFirework(world: World, pos: Vector, effect: FireworkEffect, distance: Double = 128.0) = world.playFirework(pos, effect, distance)
+fun playFirework(world: World, loc: Location, effect: FireworkEffect, distance: Double = 128.0) = world.playFirework(loc, effect, distance)

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -7,3 +7,4 @@ libraries:
   - io.github.monun:tap:4.1.9
   - io.github.monun:invfx:3.0.1
   - io.github.monun:kommand:2.6.6
+  - org.scala-lang:scala-library:2.13.6


### PR DESCRIPTION
---
<h1>Scala Support</h1>

### 목적
- Scala 로 능력을 제작하거나 그러고자 하는 사람들을 위해 만들어 졌습니다.

### 주의할 점
- #67
- 위 이슈의 임시방편으로 로딩할 클레스 이름에서 느낌표 접미사를 빼고 로딩을 진행하도록 되어 있습니다.
- 다른 해결책이 있다면 알려주시면 감사하겠습니다.

### 주요 변경사항
- 페키지 io.github.monun.psychics.scalasupport 안에 Scala 작성을 위한 도구 몇 가지가 있습니다.
- org.scala-lang:scala-library:2.13.6 의존성 추가 & 서버 실행시 해당 라이브러리를 로딩합니다.
- scala 작성을 위한 예시 ability 가 있습니다. (ability-sample 과 기능 동일)

### +참고
- ActiveAbility의 onCast 작성에 문제가 있는데 그냥 action 의 타입은 그냥 WandAction 으로 해주시고 override 오류는 그냥 무시하고 빌드 해주시변 됩니다.
---
<h1>Bundle Abilities</h1>

<b>1. necromancer (강령술사)</b>
![minecraft_spo_necromancer](https://user-images.githubusercontent.com/88622655/135735708-a2f31046-b637-448a-93bf-916b0cdf6223.gif)![화면 캡처 2021-10-03 124522](https://user-images.githubusercontent.com/88622655/135738832-35274506-4023-4b00-b9b8-8d55691780da.png)

<b>2. location-magic (위치 마술)</b>
![ezgif-3-f6359ab30808](https://user-images.githubusercontent.com/88622655/136357058-05281511-d32f-498a-a72a-a0f8e00b2b75.gif)![제목 없음_320x249](https://user-images.githubusercontent.com/88622655/136356427-635131cd-02ec-44fc-8930-471e4f5e0301.jpg)