### PR TITLE
Support Paper 1.20.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Psychics (paper 기반의 능력자 플러그인)
 
 [![Kotlin](https://img.shields.io/badge/java-17-ED8B00.svg?logo=java)](https://www.azul.com/)
-[![Kotlin](https://img.shields.io/badge/kotlin-1.7.10-585DEF.svg?logo=kotlin)](http://kotlinlang.org)
-[![Gradle](https://img.shields.io/badge/gradle-7.4-02303A.svg?logo=gradle)](https://gradle.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-1.7.21-585DEF.svg?logo=kotlin)](http://kotlinlang.org)
+[![Gradle](https://img.shields.io/badge/gradle-7.6-02303A.svg?logo=gradle)](https://gradle.org)
 [![GitHub](https://img.shields.io/github/license/monun/psychics)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![Kotlin](https://img.shields.io/badge/youtube-각별-red.svg?logo=youtube)](https://www.youtube.com/channel/UCDrAR1OWC2MD4s0JLetN0MA)
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@
 현재 개발 진행중으로 배포버전이 없습니다.
 
 * [docs](https://monun.github.io/psychics/)
+
+---
+## TODO
+
+* [ ] Show Firework without Tap Effect Util 

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@
 ---
 ## TODO
 
-* [ ] Show Firework without Tap Effect Util 
+* [x] Show Firework without Tap Effect Util 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Psychics (paper 기반의 능력자 플러그인)
 
-[![Kotlin](https://img.shields.io/badge/java-16.0.2-ED8B00.svg?logo=java)](https://www.azul.com/)
-[![Kotlin](https://img.shields.io/badge/kotlin-1.5.21-585DEF.svg?logo=kotlin)](http://kotlinlang.org)
-[![Gradle](https://img.shields.io/badge/gradle-7.2-02303A.svg?logo=gradle)](https://gradle.org)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.monun/psychics)](https://search.maven.org/artifact/io.github.monun/psychics)
+[![Kotlin](https://img.shields.io/badge/java-17-ED8B00.svg?logo=java)](https://www.azul.com/)
+[![Kotlin](https://img.shields.io/badge/kotlin-1.7.10-585DEF.svg?logo=kotlin)](http://kotlinlang.org)
+[![Gradle](https://img.shields.io/badge/gradle-7.4-02303A.svg?logo=gradle)](https://gradle.org)
 [![GitHub](https://img.shields.io/github/license/monun/psychics)](https://www.gnu.org/licenses/gpl-3.0.html)
 [![Kotlin](https://img.shields.io/badge/youtube-각별-red.svg?logo=youtube)](https://www.youtube.com/channel/UCDrAR1OWC2MD4s0JLetN0MA)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.7.10"
+    kotlin("jvm") version "1.7.21"
 }
 
 java {
@@ -22,11 +22,11 @@ subprojects {
     }
 
     dependencies {
-        compileOnly("io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT")
 
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
 
-        implementation("io.github.monun:tap-api:4.6.2")
+        implementation("io.github.monun:tap-api:4.9.1")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,11 +22,11 @@ subprojects {
     }
 
     dependencies {
-        compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT")
 
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
 
-        implementation("io.github.monun:tap-api:4.9.4")
+        implementation("io.github.monun:tap-api:4.9.6")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,11 +22,11 @@ subprojects {
     }
 
     dependencies {
-        compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.19.4-R0.1-SNAPSHOT")
 
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
 
-        implementation("io.github.monun:tap-api:4.9.1")
+        implementation("io.github.monun:tap-api:4.9.4")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    kotlin("jvm") version "1.5.21"
+    kotlin("jvm") version "1.7.10"
 }
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(16))
+        languageVersion.set(JavaLanguageVersion.of(17))
     }
 }
 
@@ -16,7 +16,7 @@ allprojects {
     tasks {
         withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class) {
             kotlinOptions {
-                jvmTarget = "16"
+                jvmTarget = "17"
             }
         }
     }
@@ -30,12 +30,12 @@ subprojects {
     }
 
     dependencies {
-        compileOnly("io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.19-R0.1-SNAPSHOT")
 
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
 
-        implementation("io.github.monun:tap-api:4.1.9")
+        implementation("io.github.monun:tap-api:4.6.0")
 
         testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,11 +22,11 @@ subprojects {
     }
 
     dependencies {
-        compileOnly("io.papermc.paper:paper-api:1.19-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT")
 
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
 
-        implementation("io.github.monun:tap-api:4.6.0")
+        implementation("io.github.monun:tap-api:4.6.2")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,14 +12,6 @@ allprojects {
     repositories {
         mavenCentral()
     }
-
-    tasks {
-        withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class) {
-            kotlinOptions {
-                jvmTarget = "17"
-            }
-        }
-    }
 }
 
 subprojects {
@@ -36,9 +28,5 @@ subprojects {
         implementation(kotlin("reflect"))
 
         implementation("io.github.monun:tap-api:4.6.0")
-
-        testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.2")
-        testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.2")
-        testImplementation("org.mockito:mockito-core:3.6.28")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,6 @@ subprojects {
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))
 
-        implementation("io.github.monun:tap-api:4.9.6")
+        implementation("io.github.monun:tap-api:4.9.8")
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/psychics-abilities/ability-berserker/src/main/kotlin/io/github/monun/psychics/ability/berserker/AbilityBerserker.kt
+++ b/psychics-abilities/ability-berserker/src/main/kotlin/io/github/monun/psychics/ability/berserker/AbilityBerserker.kt
@@ -2,6 +2,7 @@ package io.github.monun.psychics.ability.berserker
 
 import io.github.monun.psychics.AbilityConcept
 import io.github.monun.psychics.ActiveAbility
+import io.github.monun.psychics.effect.spawnFirework
 import io.github.monun.tap.config.Config
 import io.github.monun.tap.config.Name
 //import io.github.monun.tap.effect.playFirework
@@ -64,7 +65,7 @@ class AbilityBerserker : ActiveAbility<AbilityConceptBerserker>(), Listener {
         val location = player.location.apply { y += 2.0 }
         val world = location.world
         val firework = FireworkEffect.builder().with(FireworkEffect.Type.BURST).withColor(Color.RED).withFlicker().build()
-        //world.playFirework(location, firework) //TODO: Show Firework without Tap Effect Util
+        world.spawnFirework(location, firework, psychics.plugin)
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/psychics-abilities/ability-berserker/src/main/kotlin/io/github/monun/psychics/ability/berserker/AbilityBerserker.kt
+++ b/psychics-abilities/ability-berserker/src/main/kotlin/io/github/monun/psychics/ability/berserker/AbilityBerserker.kt
@@ -4,7 +4,7 @@ import io.github.monun.psychics.AbilityConcept
 import io.github.monun.psychics.ActiveAbility
 import io.github.monun.tap.config.Config
 import io.github.monun.tap.config.Name
-import io.github.monun.tap.effect.playFirework
+//import io.github.monun.tap.effect.playFirework
 import org.bukkit.*
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -64,7 +64,7 @@ class AbilityBerserker : ActiveAbility<AbilityConceptBerserker>(), Listener {
         val location = player.location.apply { y += 2.0 }
         val world = location.world
         val firework = FireworkEffect.builder().with(FireworkEffect.Type.BURST).withColor(Color.RED).withFlicker().build()
-        world.playFirework(location, firework)
+        //world.playFirework(location, firework) //TODO: Show Firework without Tap Effect Util
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/psychics-abilities/ability-berserker/src/main/kotlin/io/github/monun/psychics/ability/berserker/AbilityBerserker.kt
+++ b/psychics-abilities/ability-berserker/src/main/kotlin/io/github/monun/psychics/ability/berserker/AbilityBerserker.kt
@@ -65,7 +65,7 @@ class AbilityBerserker : ActiveAbility<AbilityConceptBerserker>(), Listener {
         val location = player.location.apply { y += 2.0 }
         val world = location.world
         val firework = FireworkEffect.builder().with(FireworkEffect.Type.BURST).withColor(Color.RED).withFlicker().build()
-        world.spawnFirework(location, firework, psychics.plugin)
+        world.spawnFirework(location, firework, psychic.plugin)
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/psychics-abilities/ability-bomber/src/main/kotlin/io/github/monun/psychics/ability/bomber/AbilityBomber.kt
+++ b/psychics-abilities/ability-bomber/src/main/kotlin/io/github/monun/psychics/ability/bomber/AbilityBomber.kt
@@ -170,19 +170,19 @@ class AbilityBomber : ActiveAbility<AbilityConceptBomber>(), Listener {
      * 가짜 TNT 효과
      */
     inner class TNT(location: Location) {
-        private val stand: FakeEntity
-        private val tnt: FakeEntity
+        private val stand: FakeEntity<ArmorStand>
+        private val tnt: FakeEntity<TNTPrimed>
 
         init {
             val psychic = psychic
             stand = psychic.spawnFakeEntity(location, ArmorStand::class.java).apply {
-                updateMetadata<ArmorStand> {
+                updateMetadata {
                     isMarker = true
                     isInvisible = true
                 }
             }
             tnt = psychic.spawnFakeEntity(location, TNTPrimed::class.java).apply {
-                updateMetadata<TNTPrimed> {
+                updateMetadata {
                     fuseTicks = (durationTime / 50L).toInt()
                 }
             }

--- a/psychics-abilities/ability-fangs/src/main/kotlin/io/github/monun/psychics/ability/fangs/AbilityFangs.kt
+++ b/psychics-abilities/ability-fangs/src/main/kotlin/io/github/monun/psychics/ability/fangs/AbilityFangs.kt
@@ -134,7 +134,7 @@ class AbilityFangs : ActiveAbility<AbilityConceptFangs>(), Listener {
 
     private class Fang(
         val location: Location,
-        val fakeEntity: FakeEntity,
+        val fakeEntity: FakeEntity<EvokerFangs>,
         var nextRunTime: Long,
         val damaged: MutableSet<Entity>
     ) : Comparable<Fang> {

--- a/psychics-abilities/ability-magic-archery/src/main/kotlin/io/github/monun/psychics/ability/magicarchery/AbilityMagicArchery.kt
+++ b/psychics-abilities/ability-magic-archery/src/main/kotlin/io/github/monun/psychics/ability/magicarchery/AbilityMagicArchery.kt
@@ -9,7 +9,7 @@ import io.github.monun.psychics.damage.DamageType
 import io.github.monun.psychics.damage.psychicDamage
 import io.github.monun.psychics.util.TargetFilter
 import io.github.monun.tap.config.Name
-import io.github.monun.tap.effect.playFirework
+//import io.github.monun.tap.effect.playFirework
 import io.github.monun.tap.trail.TrailSupport
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
@@ -132,7 +132,7 @@ class AbilityMagicArchery : Ability<AbilityConceptMagicArchery>(), Listener {
                     val box = target.boundingBox
                     val effect = FireworkEffect.builder().with(FireworkEffect.Type.BURST)
                         .withColor(if (force == 1.0F) Color.RED else Color.ORANGE).build()
-                    world.playFirework(box.centerX, box.maxY + 0.5, box.centerZ, effect)
+                    //world.playFirework(box.centerX, box.maxY + 0.5, box.centerZ, effect) //TODO: Show Firework without Tap Effect Util
                 }
             }
 

--- a/psychics-abilities/ability-magic-archery/src/main/kotlin/io/github/monun/psychics/ability/magicarchery/AbilityMagicArchery.kt
+++ b/psychics-abilities/ability-magic-archery/src/main/kotlin/io/github/monun/psychics/ability/magicarchery/AbilityMagicArchery.kt
@@ -7,6 +7,7 @@ import io.github.monun.psychics.attribute.EsperAttribute
 import io.github.monun.psychics.damage.Damage
 import io.github.monun.psychics.damage.DamageType
 import io.github.monun.psychics.damage.psychicDamage
+import io.github.monun.psychics.effect.spawnFirework
 import io.github.monun.psychics.util.TargetFilter
 import io.github.monun.tap.config.Name
 //import io.github.monun.tap.effect.playFirework
@@ -132,7 +133,7 @@ class AbilityMagicArchery : Ability<AbilityConceptMagicArchery>(), Listener {
                     val box = target.boundingBox
                     val effect = FireworkEffect.builder().with(FireworkEffect.Type.BURST)
                         .withColor(if (force == 1.0F) Color.RED else Color.ORANGE).build()
-                    //world.playFirework(box.centerX, box.maxY + 0.5, box.centerZ, effect) //TODO: Show Firework without Tap Effect Util
+                    world.spawnFirework(box.centerX, box.maxY + 0.5, box.centerZ, effect, psychic.plugin)
                 }
             }
 

--- a/psychics-abilities/ability-sample/src/main/kotlin/io/github/monun/psychics/ability/sample/AbilitySample.kt
+++ b/psychics-abilities/ability-sample/src/main/kotlin/io/github/monun/psychics/ability/sample/AbilitySample.kt
@@ -6,6 +6,7 @@ import io.github.monun.psychics.Channel
 import io.github.monun.psychics.attribute.EsperAttribute
 import io.github.monun.psychics.damage.Damage
 import io.github.monun.psychics.damage.DamageType
+import io.github.monun.psychics.effect.spawnFirework
 import io.github.monun.psychics.util.hostileFilter
 import io.github.monun.tap.config.Name
 //import io.github.monun.tap.effect.playFirework
@@ -35,10 +36,6 @@ class AbilityConceptSample : AbilityConcept() {
 class AbilitySample : ActiveAbility<AbilityConceptSample>(), Listener {
     companion object {
         private val effect = FireworkEffect.builder().with(FireworkEffect.Type.BURST).withColor(Color.RED).build()
-
-        private fun LivingEntity.playPsychicEffect() {
-            //orld.playFirework(location, effect) //TODO: Show Firework without Tap Effect Util
-        }
     }
 
     override fun onInitialize() {
@@ -84,5 +81,9 @@ class AbilitySample : ActiveAbility<AbilityConceptSample>(), Listener {
 
         target.psychicDamage()
         target.playPsychicEffect()
+    }
+
+    private fun LivingEntity.playPsychicEffect() {
+        world.spawnFirework(location, effect, psychic.plugin)
     }
 }

--- a/psychics-abilities/ability-sample/src/main/kotlin/io/github/monun/psychics/ability/sample/AbilitySample.kt
+++ b/psychics-abilities/ability-sample/src/main/kotlin/io/github/monun/psychics/ability/sample/AbilitySample.kt
@@ -8,7 +8,7 @@ import io.github.monun.psychics.damage.Damage
 import io.github.monun.psychics.damage.DamageType
 import io.github.monun.psychics.util.hostileFilter
 import io.github.monun.tap.config.Name
-import io.github.monun.tap.effect.playFirework
+//import io.github.monun.tap.effect.playFirework
 import net.kyori.adventure.text.Component.text
 import org.bukkit.*
 import org.bukkit.entity.LivingEntity
@@ -37,7 +37,7 @@ class AbilitySample : ActiveAbility<AbilityConceptSample>(), Listener {
         private val effect = FireworkEffect.builder().with(FireworkEffect.Type.BURST).withColor(Color.RED).build()
 
         private fun LivingEntity.playPsychicEffect() {
-            world.playFirework(location, effect)
+            //orld.playFirework(location, effect) //TODO: Show Firework without Tap Effect Util
         }
     }
 

--- a/psychics-abilities/ability-sling-shot/src/main/kotlin/io/github/monun/psychics/ability/slingshot/AbilitySlingShot.kt
+++ b/psychics-abilities/ability-sling-shot/src/main/kotlin/io/github/monun/psychics/ability/slingshot/AbilitySlingShot.kt
@@ -76,7 +76,7 @@ class AbilitySlingShot : Ability<AbilityConceptSlingShot>(), Listener {
                     val projectile = CobblestoneProjectile().apply {
                         cobblestone =
                             this@AbilitySlingShot.psychic.spawnFakeEntity(location, ArmorStand::class.java).apply {
-                                updateMetadata<ArmorStand> {
+                                updateMetadata {
                                     isVisible = false
                                     isMarker = true
                                 }
@@ -97,7 +97,7 @@ class AbilitySlingShot : Ability<AbilityConceptSlingShot>(), Listener {
     }
 
     inner class CobblestoneProjectile : PsychicProjectile(1200, concept.range) {
-        lateinit var cobblestone: FakeEntity
+        lateinit var cobblestone: FakeEntity<ArmorStand>
 
         override fun onPreUpdate() {
             velocity = velocity.apply { y -= concept.stoneGravity }

--- a/psychics-abilities/ability-storm-breaker/src/main/kotlin/io/github/monun/psychics/ability/stormbreaker/AbilityStormBreaker.kt
+++ b/psychics-abilities/ability-storm-breaker/src/main/kotlin/io/github/monun/psychics/ability/stormbreaker/AbilityStormBreaker.kt
@@ -109,7 +109,7 @@ class AbilityConceptStormBreaker : AbilityConcept() {
 }
 
 class AbilityStormBreaker : Ability<AbilityConceptStormBreaker>() {
-    private var hittedAxe: FakeEntity? = null
+    private var hittedAxe: FakeEntity<ArmorStand>? = null
 
     override fun onEnable() {
         psychic.registerEvents(AxeListener())
@@ -207,7 +207,7 @@ class AbilityStormBreaker : Ability<AbilityConceptStormBreaker>() {
                                 ).apply {
                                     velocity = location.direction.multiply(concept.axeSpeed)
 
-                                    updateMetadata<ArmorStand> {
+                                    updateMetadata {
                                         isMarker = true
                                         invisible = true
                                     }
@@ -229,7 +229,7 @@ class AbilityStormBreaker : Ability<AbilityConceptStormBreaker>() {
     inner class AxeProjectile(
         private val damage: Damage, private val item: ItemStack
     ) : PsychicProjectile(1200, concept.range) {
-        var axe: FakeEntity? = null
+        var axe: FakeEntity<ArmorStand>? = null
 
         override fun onPreUpdate() {
             velocity = velocity.apply { y -= concept.axeGravity }
@@ -239,7 +239,7 @@ class AbilityStormBreaker : Ability<AbilityConceptStormBreaker>() {
             val to = movement.to
             axe?.let { axe ->
                 axe.moveTo(to.clone().apply { y -= 1.62; yaw -= 90.0F })
-                axe.updateMetadata<ArmorStand> {
+                axe.updateMetadata {
                     headPose = EulerAngle(0.0, 0.0, ticks * -0.5)
                 }
             }
@@ -273,7 +273,7 @@ class AbilityStormBreaker : Ability<AbilityConceptStormBreaker>() {
                     axe?.let { axe ->
                         this.axe = null
                         axe.moveTo(hitLocation.clone().apply { y -= 0.5; yaw = from.yaw - 90.0F })
-                        axe.updateMetadata<ArmorStand> {
+                        axe.updateMetadata {
                             headPose = EulerAngle(0.0, 0.0, (-180.0).toRadians())
                         }
                         hittedAxe = axe

--- a/psychics-abilities/ability-storm-breaker/src/main/kotlin/io/github/monun/psychics/ability/stormbreaker/AbilityStormBreaker.kt
+++ b/psychics-abilities/ability-storm-breaker/src/main/kotlin/io/github/monun/psychics/ability/stormbreaker/AbilityStormBreaker.kt
@@ -14,7 +14,6 @@ import io.github.monun.tap.config.Name
 import io.github.monun.tap.fake.FakeEntity
 import io.github.monun.tap.fake.Movement
 import io.github.monun.tap.fake.Trail
-import io.github.monun.tap.fake.invisible
 import io.github.monun.tap.math.normalizeAndLength
 import io.github.monun.tap.math.toRadians
 import io.github.monun.tap.trail.TrailSupport
@@ -209,7 +208,7 @@ class AbilityStormBreaker : Ability<AbilityConceptStormBreaker>() {
 
                                     updateMetadata {
                                         isMarker = true
-                                        invisible = true
+                                        isVisible = false
                                     }
                                     updateEquipment {
                                         helmet = item.clone()

--- a/psychics-abilities/build.gradle.kts
+++ b/psychics-abilities/build.gradle.kts
@@ -49,8 +49,19 @@ subprojects {
 }
 
 gradle.buildFinished {
-    val libs = File(buildDir, "libs")
+    val libs = subprojects
+        .map { File(it.buildDir, "libs") }
+        .filter { it.exists() }
+        .mapNotNull { it.listFiles()!!.singleOrNull() }
 
-    if (libs.exists())
-        zipTo(File(buildDir, "abilities.zip"), libs)
+    val abilitiesDir = File(buildDir,"abilities")
+
+    abilitiesDir.mkdir()
+
+    libs.forEach {
+        val newFile = File(abilitiesDir,it.name)
+        it.copyTo(newFile,true)
+    }
+
+    zipTo(File(buildDir, "abilities.zip"), abilitiesDir)
 }

--- a/psychics-abilities/build.gradle.kts
+++ b/psychics-abilities/build.gradle.kts
@@ -49,13 +49,17 @@ subprojects {
 }
 
 gradle.buildFinished {
+    if (!buildDir.exists()) buildDir.mkdir()
+
     val abilitiesDir = File(buildDir,"abilities")
     abilitiesDir.mkdir()
 
     subprojects
-        .map { File(it.buildDir, "libs") }
-        .filter { it.exists() }
-        .mapNotNull { it.listFiles()!!.singleOrNull() }
+        .map { File(it.buildDir, "libs") to it }
+        .filter { (it,_) -> it.exists() }
+        .mapNotNull { (it,project) -> it.listFiles()!!.find {
+            it.nameWithoutExtension == "${project.group}.${project.name.removePrefix("ability-")}"
+        } }
         .forEach {
             val newFile = File(abilitiesDir,it.name)
             it.copyTo(newFile,true)

--- a/psychics-abilities/build.gradle.kts
+++ b/psychics-abilities/build.gradle.kts
@@ -49,19 +49,17 @@ subprojects {
 }
 
 gradle.buildFinished {
-    val libs = subprojects
+    val abilitiesDir = File(buildDir,"abilities")
+    abilitiesDir.mkdir()
+
+    subprojects
         .map { File(it.buildDir, "libs") }
         .filter { it.exists() }
         .mapNotNull { it.listFiles()!!.singleOrNull() }
-
-    val abilitiesDir = File(buildDir,"abilities")
-
-    abilitiesDir.mkdir()
-
-    libs.forEach {
-        val newFile = File(abilitiesDir,it.name)
-        it.copyTo(newFile,true)
-    }
+        .forEach {
+            val newFile = File(abilitiesDir,it.name)
+            it.copyTo(newFile,true)
+        }
 
     zipTo(File(buildDir, "abilities.zip"), abilitiesDir)
 }

--- a/psychics-core/build.gradle.kts
+++ b/psychics-core/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    id("org.jetbrains.dokka") version "1.5.0"
+    id("org.jetbrains.dokka") version "1.7.10"
 }
 
 dependencies {
-    implementation("io.github.monun:kommand-api:2.6.6")
-    implementation("io.github.monun:invfx-api:3.0.1")
+    implementation("io.github.monun:kommand-api:2.12.0")
+    implementation("io.github.monun:invfx-api:3.1.0")
 }
 
 tasks {

--- a/psychics-core/build.gradle.kts
+++ b/psychics-core/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
-    id("org.jetbrains.dokka") version "1.7.10"
+    id("org.jetbrains.dokka") version "1.7.20"
 }
 
 dependencies {
-    implementation("io.github.monun:kommand-api:2.13.0")
-    implementation("io.github.monun:invfx-api:3.1.0")
+    implementation("io.github.monun:kommand-api:3.1.2")
+    implementation("io.github.monun:invfx-api:3.3.0")
 }
 
 tasks {

--- a/psychics-core/build.gradle.kts
+++ b/psychics-core/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("io.github.monun:kommand-api:3.1.2")
+    implementation("io.github.monun:kommand-api:3.1.3")
     implementation("io.github.monun:invfx-api:3.3.0")
 }
 

--- a/psychics-core/build.gradle.kts
+++ b/psychics-core/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("io.github.monun:kommand-api:2.12.0")
+    implementation("io.github.monun:kommand-api:2.13.0")
     implementation("io.github.monun:invfx-api:3.1.0")
 }
 

--- a/psychics-core/build.gradle.kts
+++ b/psychics-core/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation("io.github.monun:kommand-api:3.1.3")
+    implementation("io.github.monun:kommand-api:3.1.6")
     implementation("io.github.monun:invfx-api:3.3.0")
 }
 

--- a/psychics-core/build.gradle.kts
+++ b/psychics-core/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    implementation("io.github.monun:kommand-api:3.1.6")
-    implementation("io.github.monun:invfx-api:3.3.0")
+    implementation("io.github.monun:kommand-api:3.1.7")
+    implementation("io.github.monun:invfx-api:3.3.2")
 }
 
 tasks {

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/Psychic.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/Psychic.kt
@@ -38,6 +38,8 @@ import org.bukkit.boss.BossBar
 import org.bukkit.configuration.ConfigurationSection
 import org.bukkit.entity.ArmorStand
 import org.bukkit.entity.Entity
+import org.bukkit.entity.FallingBlock
+import org.bukkit.entity.Item
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerEvent
 import org.bukkit.inventory.ItemStack
@@ -132,7 +134,7 @@ class Psychic internal constructor(
 
     private lateinit var listeners: ArrayList<RegisteredEntityListener>
 
-    private lateinit var fakeEntities: MutableSet<FakeEntity>
+    private lateinit var fakeEntities: MutableSet<FakeEntity<*>>
 
     private var prevUpdateTime = 0L
 
@@ -166,7 +168,7 @@ class Psychic internal constructor(
         ticker = Ticker.precision()
         projectiles = FakeProjectileManager()
         listeners = arrayListOf()
-        fakeEntities = Collections.newSetFromMap(WeakHashMap<FakeEntity, Boolean>())
+        fakeEntities = Collections.newSetFromMap(WeakHashMap())
 
         if (concept.mana > 0.0) {
             manaBar = Bukkit.createBossBar(null, concept.manaColor, BarStyle.SEGMENTED_10).apply {
@@ -360,7 +362,7 @@ class Psychic internal constructor(
      * @exception IllegalArgumentException 유효하지 않은 객체일때 발생
      * @exception IllegalArgumentException 활성화되지 않은 객체일때 발생
      */
-    fun spawnFakeEntity(location: Location, entityClass: Class<out Entity>): FakeEntity {
+    fun <T:Entity> spawnFakeEntity(location: Location, entityClass: Class<T>): FakeEntity<T> {
         checkState()
         checkEnabled()
 
@@ -378,7 +380,7 @@ class Psychic internal constructor(
      * @exception IllegalArgumentException 유효하지 않은 객체일때 발생
      * @exception IllegalArgumentException 활성화되지 않은 객체일때 발생
      */
-    fun spawnFakeFallingBlock(location: Location, blockData: BlockData): FakeEntity {
+    fun spawnFakeFallingBlock(location: Location, blockData: BlockData): FakeEntity<FallingBlock> {
         checkState()
         checkEnabled()
 
@@ -396,7 +398,7 @@ class Psychic internal constructor(
      * @exception IllegalArgumentException 유효하지 않은 객체일때 발생
      * @exception IllegalArgumentException 활성화되지 않은 객체일때 발생
      */
-    fun spawnItem(location: Location, itemStack: ItemStack): FakeEntity {
+    fun spawnItem(location: Location, itemStack: ItemStack): FakeEntity<Item> {
         checkState()
         checkEnabled()
 
@@ -414,9 +416,9 @@ class Psychic internal constructor(
      * @exception IllegalArgumentException 유효하지 않은 객체일때 발생
      * @exception IllegalArgumentException 활성화되지 않은 객체일때 발생
      */
-    fun spawnMarker(location: Location): FakeEntity {
+    fun spawnMarker(location: Location): FakeEntity<ArmorStand> {
         return spawnFakeEntity(location, ArmorStand::class.java).apply {
-            updateMetadata<ArmorStand> {
+            updateMetadata {
                 isMarker = true
                 isInvisible = true
             }
@@ -431,7 +433,7 @@ class Psychic internal constructor(
      * @exception IllegalArgumentException 유효하지 않은 객체일때 발생
      * @exception IllegalArgumentException 활성화되지 않은 객체일때 발생
      */
-    fun marker(passenger: FakeEntity): FakeEntity {
+    fun <T:Entity> marker(passenger: FakeEntity<T>): FakeEntity<ArmorStand> {
         return spawnMarker(passenger.location).apply { addPassenger(passenger) }
     }
 

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/command/KommandPsychics.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/command/KommandPsychics.kt
@@ -43,7 +43,9 @@ internal object KommandPsychics {
         this.manager = manager
 
         kommand.register("psychics", "psy") {
-            permission("psychics.commands")
+            requires {
+                hasPermission("psychics.commands")
+            }
 
             val psychicConceptArgument = dynamic { _, input ->
                 manager.getPsychicConcept(input)

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/effect/FireworkSupport.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/effect/FireworkSupport.kt
@@ -6,13 +6,13 @@ import org.bukkit.World
 import org.bukkit.plugin.Plugin
 import org.bukkit.entity.Firework
 import org.bukkit.inventory.meta.FireworkMeta
+import org.bukkit.metadata.FixedMetadataValue
 
 fun World.spawnFirework(
-    x: Double, y: Double, z: Double,
-    world: World, effect: FireworkEffect, plugin: Plugin,
+    x: Double, y: Double, z: Double, effect: FireworkEffect, plugin: Plugin,
     hasDamage: Boolean = false, power: Int = 0, ticksToDetonate: Int = 0
 ): Firework {
-    val location = Location(world, x, y, z)
+    val location = Location(this, x, y, z)
     val firework: Firework = location.world.spawn(location, Firework::class.java)
     val fireworkMeta: FireworkMeta = firework.fireworkMeta
     fireworkMeta.addEffect(effect)
@@ -29,12 +29,12 @@ fun World.spawnFirework(
     effect: FireworkEffect, plugin: Plugin,
     hasDamage: Boolean = false, power: Int = 0, ticksToDetonate: Int = 0
 ) =
-    spawnFirework(loc.x, loc.y, loc.z, loc.world, effect, hasDamage, power, ticksToDetonate)
+    spawnFirework(loc.x, loc.y, loc.z, effect, plugin, hasDamage, power, ticksToDetonate)
 
 val NO_DAMAGE_FIREWORK_FLAG = "NoDamageFirework"
 
 fun Firework.disableDamage(plugin: Plugin) {
-    setMetadata(NO_DAMAGE_FIREWORK_FLAG, new FixedMetadataValue(plugin, true))
+    setMetadata(NO_DAMAGE_FIREWORK_FLAG, FixedMetadataValue(plugin, true))
 }
 
 

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/effect/FireworkSupport.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/effect/FireworkSupport.kt
@@ -1,0 +1,40 @@
+package io.github.monun.psychics.effect
+
+import org.bukkit.FireworkEffect
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.plugin.Plugin
+import org.bukkit.entity.Firework
+import org.bukkit.inventory.meta.FireworkMeta
+
+fun World.spawnFirework(
+    x: Double, y: Double, z: Double,
+    world: World, effect: FireworkEffect, plugin: Plugin
+    hasDamage: Boolean = false, power: Int = 0, ticksToDetonate: Int = 0
+): Firework {
+    val location = Location(world, x, y, z)
+    val firework: Firework = location.world.spawn(location, Firework::class.java)
+    val fireworkMeta: FireworkMeta = firework.fireworkMeta
+    fireworkMeta.addEffect(effect)
+    fireworkMeta.power = power
+    firework.fireworkMeta = fireworkMeta
+    firework.ticksToDetonate = ticksToDetonate
+    if (!hasDamage) {
+        firework.disableDamage(plugin)
+    }
+    return firework
+}
+fun World.spawnFirework(
+    loc: Location,
+    effect: FireworkEffect, plugin: Plugin
+    hasDamage: Boolean = false, power: Int = 0, ticksToDetonate: Int = 0
+) =
+    spawnFirework(loc.x, loc.y, loc.z, loc.world, effect, hasDamage, power, ticksToDetonate)
+
+val NO_DAMAGE_FIREWORK_FLAG = "NoDamageFirework"
+
+fun Firework.disableDamage(plugin: Plugin) {
+    setMetadata(NO_DAMAGE_FIREWORK_FLAG, new FixedMetadataValue(plugin, true))
+}
+
+

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/effect/FireworkSupport.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/effect/FireworkSupport.kt
@@ -9,7 +9,7 @@ import org.bukkit.inventory.meta.FireworkMeta
 
 fun World.spawnFirework(
     x: Double, y: Double, z: Double,
-    world: World, effect: FireworkEffect, plugin: Plugin
+    world: World, effect: FireworkEffect, plugin: Plugin,
     hasDamage: Boolean = false, power: Int = 0, ticksToDetonate: Int = 0
 ): Firework {
     val location = Location(world, x, y, z)
@@ -26,7 +26,7 @@ fun World.spawnFirework(
 }
 fun World.spawnFirework(
     loc: Location,
-    effect: FireworkEffect, plugin: Plugin
+    effect: FireworkEffect, plugin: Plugin,
     hasDamage: Boolean = false, power: Int = 0, ticksToDetonate: Int = 0
 ) =
     spawnFirework(loc.x, loc.y, loc.z, loc.world, effect, hasDamage, power, ticksToDetonate)

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/plugin/EventListener.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/plugin/EventListener.kt
@@ -20,6 +20,7 @@ package io.github.monun.psychics.plugin
 import com.destroystokyo.paper.event.inventory.PrepareResultEvent
 import com.destroystokyo.paper.event.player.PlayerPostRespawnEvent
 import io.github.monun.psychics.*
+import io.github.monun.psychics.effect.NO_DAMAGE_FIREWORK_FLAG
 import io.github.monun.psychics.item.enchantability
 import io.github.monun.psychics.item.isPsychicbound
 import io.github.monun.psychics.item.psionicsLevel
@@ -197,6 +198,21 @@ class EventListener(
             }
         }
     }
+
+
+    @EventHandler
+    fun onEntityDamageByEntity(event: EntityDamageByEntityEvent) {
+        val damager = event.damager
+        val cause = event.cause
+        if (
+            damager is Firework &&
+            cause == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION &&
+            damager.hasMetadata(NO_DAMAGE_FIREWORK_FLAG)
+            ) {
+            event.isCancelled = true
+        }
+    }
+
 
     private val Player.esper: Esper
         get() = requireNotNull(psychicManager.getEsper(this))

--- a/psychics-core/src/main/kotlin/io/github/monun/psychics/plugin/EventListener.kt
+++ b/psychics-core/src/main/kotlin/io/github/monun/psychics/plugin/EventListener.kt
@@ -28,11 +28,14 @@ import io.github.monun.psychics.item.removeAllPsychicbounds
 import io.github.monun.tap.fake.FakeEntityServer
 import org.bukkit.GameMode
 import org.bukkit.Material
+import org.bukkit.entity.Firework
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.block.Action
 import org.bukkit.event.enchantment.EnchantItemEvent
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.entity.EntityRegainHealthEvent
 import org.bukkit.event.entity.ItemSpawnEvent
 import org.bukkit.event.inventory.InventoryClickEvent

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -5,5 +5,5 @@ version: $version
 author: Monun
 libraries:
   - io.github.monun:tap-core:4.6.0
-  - io.github.monun:invfx:3.1.0
-  - io.github.monun:kommand:2.12.0
+  - io.github.monun:invfx-core:3.1.0
+  - io.github.monun:kommand-core:2.12.0

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -5,5 +5,5 @@ version: $version
 author: Monun
 libraries:
   - io.github.monun:tap-core:4.6.0
-  - io.github.monun:invfx-core:3.1.0
+  - io.github.monun:invfx:3.1.0
   - io.github.monun:kommand-core:2.12.0

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -4,6 +4,6 @@ api-version: '1.20'
 version: $version
 author: Monun
 libraries:
-  - io.github.monun:tap-core:4.9.6
-  - io.github.monun:invfx-core:3.3.0
-  - io.github.monun:kommand-core:3.1.6
+  - io.github.monun:tap-core:4.9.8
+  - io.github.monun:invfx-core:3.3.2
+  - io.github.monun:kommand-core:3.1.7

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -4,6 +4,6 @@ api-version: '1.19'
 version: $version
 author: Monun
 libraries:
-  - io.github.monun:tap-core:4.9.1
+  - io.github.monun:tap-core:4.9.4
   - io.github.monun:invfx-core:3.3.0
-  - io.github.monun:kommand-core:3.1.2
+  - io.github.monun:kommand-core:3.1.3

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -4,6 +4,6 @@ api-version: '1.19'
 version: $version
 author: Monun
 libraries:
-  - io.github.monun:tap-core:4.6.2
-  - io.github.monun:invfx:3.1.0
-  - io.github.monun:kommand-core:2.13.0
+  - io.github.monun:tap-core:4.9.1
+  - io.github.monun:invfx-core:3.3.0
+  - io.github.monun:kommand-core:3.1.2

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -1,9 +1,9 @@
 name: Psychics
 main: io.github.monun.psychics.plugin.PsychicsPlugin
-api-version: '1.17'
+api-version: '1.19'
 version: $version
 author: Monun
 libraries:
-  - io.github.monun:tap:4.1.9
-  - io.github.monun:invfx:3.0.1
-  - io.github.monun:kommand:2.6.6
+  - io.github.monun:tap-core:4.6.0
+  - io.github.monun:invfx:3.1.0
+  - io.github.monun:kommand:2.12.0

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -1,9 +1,9 @@
 name: Psychics
 main: io.github.monun.psychics.plugin.PsychicsPlugin
-api-version: '1.19'
+api-version: '1.20'
 version: $version
 author: Monun
 libraries:
-  - io.github.monun:tap-core:4.9.4
+  - io.github.monun:tap-core:4.9.6
   - io.github.monun:invfx-core:3.3.0
-  - io.github.monun:kommand-core:3.1.3
+  - io.github.monun:kommand-core:3.1.6

--- a/psychics-core/src/main/resources/plugin.yml
+++ b/psychics-core/src/main/resources/plugin.yml
@@ -4,6 +4,6 @@ api-version: '1.19'
 version: $version
 author: Monun
 libraries:
-  - io.github.monun:tap-core:4.6.0
+  - io.github.monun:tap-core:4.6.2
   - io.github.monun:invfx:3.1.0
-  - io.github.monun:kommand-core:2.12.0
+  - io.github.monun:kommand-core:2.13.0


### PR DESCRIPTION
## 개요
Paper 1.20.1를 지원합니다.

## 주요 변경사항

### 요약

---
- Paper 1.20.1 에서 사용 가능하도록 종속성 업데이트.
- 변경된 최신 tap-api 와의 호환을 위한 일부 psychics-core 및 능력자 코드 수정.
- 제대로 된 abilities.zip 생성.
---

### 구체적인 변경사항

- Paper 1.17.1 -> 1.20.1
- 종속성 업데이트.
- - io.github.monun:tap-api:4.1.9 -> io.github.monun:tap-api:4.9.8
- - io.github.monun:kommand-api:2.6.6 -> io.github.monun:kommand-api:3.1.7
- - io.github.monun:invfx-api:3.0.1 -> io.github.monun:invfx-api:3.3.2
- 호환을 위한 psychics-core 및 능력자 수정.
- - [x] FakeEntity<T:Entity> 제너릭 문제 해결.
- - [x] tap-api 에 폭죽 생성 메소드가 빠져 따로 구현 해야됨.
- 기타 업데이트
- - Gradle 7.2 -> 7.6
- - Kotlin 1.5.21 -> 1.7.21
- - Java 16 -> 17
- 제대로 된 abilities.zip 생성
